### PR TITLE
Feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [v1.2.2]
+- Migration de la BDD Cloud vers la BDD de Rick
+- Mise en place du webhook pour récupérer les ajouts/suppressions de succès
+
 ## [v1.2.1]
 ### Added
 - Envoi d'un MP lors d'un succès "meta" débloqué (excepté le succès des 1M de points pour le moment)

--- a/models/game.js
+++ b/models/game.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const gameSchema = mongoose.Schema({
     _id: mongoose.Schema.Types.ObjectId,
     appid: Number,
+    iconHash: String,
     name: String,
     type: String,
     // TODO objet tag 'categories' ?
@@ -14,9 +15,16 @@ const gameSchema = mongoose.Schema({
     isCoop: Boolean,
     // isCoopOnline: Boolean,
     hasAchievements: Boolean, 
-    isRemoved: Boolean
+    isRemoved: Boolean,
     // TODO img url ?
-    // TODO achievements
+    // achievements
+    achievements: [{
+        apiName: String,
+        displayName: String,
+        description: String,
+        icon: String,
+        icongray: String
+    }]
 })
 
 module.exports = mongoose.model("Game", gameSchema);

--- a/models/guildConfig.js
+++ b/models/guildConfig.js
@@ -17,9 +17,13 @@ const guildConfigSchema = mongoose.Schema({
         cat_discussion_groupe: String,
         cat_discussion_groupe_2: String,
         advent: String,
-        feed_bot: String
+        feed_bot: String,
+        feed_achievement: String
     },
-    voice_channels : [String]
+    voice_channels : [String],
+    webhook : {
+        feed_achievement: String,
+    }
 })
 
 module.exports = mongoose.model("GuildConfig", guildConfigSchema);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mongoose": "^5.13.4",
     "node-schedule": "^2.0.0",
     "signale-logger": "^1.5.1",
+    "steam-user": "^4.27.0",
     "superagent": "^6.1.0",
     "winston": "^3.3.3",
     "winston-daily-rotate-file": "^4.6.1"

--- a/util/constants.js
+++ b/util/constants.js
@@ -197,6 +197,9 @@ const CHANNEL = [
     }, {
         name: 'Feed bot 🤖',
         value: 'feed_bot'
+    }, {
+        name: 'Feed achievement 🆕',
+        value: 'feed_achievement'
     },
 ]
 const SALON = {
@@ -209,7 +212,18 @@ const SALON = {
     CAT_DISCUSSION_GROUPE: "cat_discussion_groupe",
     CAT_DISCUSSION_GROUPE_2: "cat_discussion_groupe_2",
     ADVENT: "advent",
-    FEED_BOT: "feed_bot"
+    FEED_BOT: "feed_bot",
+    FEED_ACHIEVEMENT: "feed_achievement"
+}
+
+const WEBHOOK_ARRAY = [
+    { 
+        name: 'Webhook succès',
+        value: 'feed_achievement' // channel de bienvenue, affiche les nouveaux arrivants
+    }
+]
+const WEBHOOK = {
+    FEED_ACHIEVEMENT: "feed_achievement"
 }
 
 exports.MESSAGES = MESSAGES;
@@ -222,3 +236,5 @@ exports.delay = delay;
 exports.crtHour = crtHour;
 exports.CHANNEL = CHANNEL;
 exports.SALON = SALON;
+exports.WEBHOOK_ARRAY = WEBHOOK_ARRAY;
+exports.WEBHOOK = WEBHOOK;

--- a/util/functions.js
+++ b/util/functions.js
@@ -459,9 +459,13 @@ module.exports = client => {
     };
 
     // TODO a deplacer
-    client.getGuildChannel = async (guildId, salon) => {
-        const guildDB = await client.findGuildById(guildId);
+    client.getGuildChannel = async (id, salon) => {
+        const guildDB = await client.findGuildById(id);
         return guildDB?.channels[salon];
+    }
+    client.getGuildWebhook = async (id, hook) => {
+        const guildDB = await client.findGuildById(id);
+        return guildDB?.webhook[hook];
     }
 
     // config profile

--- a/util/loader.js
+++ b/util/loader.js
@@ -1,6 +1,6 @@
 const { Collection, ChannelType } = require('discord.js');
 const { RolesChannel, MsgHallHeros, MsgHallZeros, Msg, MsgDmdeAide, Game, GuildConfig } = require('../models');
-const { loadJobs, searchNewGamesJob, resetMoneyLimit, loadJobHelper, loadEventAdvent, testEcuyer } = require('./batch/batch');
+const { loadJobs, searchNewGamesJob, resetMoneyLimit, loadJobHelper, loadEventAdvent, testEcuyer, loadSteamPICS } = require('./batch/batch');
 const { createReactionCollectorGroup, moveToArchive } = require('./msg/group');
 const { Group } = require('../models/index');
 const { SALON } = require('./constants');
@@ -62,6 +62,8 @@ const loadBatch = async (client) => {
     testEcuyer(client);
 
     loadEventAdvent(client);
+
+    loadSteamPICS(client);
 }
 
 // Charge les réactions des messages des groupes

--- a/util/util.js
+++ b/util/util.js
@@ -1,3 +1,5 @@
+const { delay } = require("./constants");
+
 module.exports.escapeRegExp = (string) => {
     return string?.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
@@ -28,4 +30,48 @@ module.exports.getJSONValue = (model, path, def) => {
     } else {
         return model[parts[0]] || def;
     }
+}
+
+// retry tous les 5 mins
+module.exports.retryAfter5min = async (fn) => {
+    while (true) {
+        try {
+            await fn();
+            break;  // 'return' would work here as well
+        } catch (err) {
+            if (err.status === 429) {
+                console.log('retry ! ', err);
+                // att 5 min
+                await delay(300000);
+            } else if (err.status === 403) {
+                console.log('forbidden ..', err.status);
+                // console.log(err);
+                break; 
+            } else {
+                break; 
+            }
+        }
+    }
+    // try {
+    //     return fn();
+    // } catch (err) {
+    //     console.log('retry ! ', err);
+    //     // att 5 min
+    //     //await delay(300000);
+    //     return this.retryAfter5min(fn); 
+    // }
+
+    // return fn().catch(async function(err) { 
+    //     console.log('retry ! ', err);
+    //     // att 5 min
+    //     //await delay(300000);
+    //     return retryAfter5min(fn); 
+    // });
+}
+
+// retry forever
+module.exports.retryForever = (fn) => {
+    return fn().catch(function(err) { 
+        return retryForever(fn); 
+    });
 }


### PR DESCRIPTION
cf #63 

ajout commande manuel  `!refresh (<appid>) (all)` exécutable que par moi (pour l'instant) pour 
- fetch les infos des jeux pas encore à jour (qui n'ont pas de tableau `achievements`)
- fetch les infos d'un jeu via son appid, si présent dans BDD
- fetch TOUS les jeux (exactement comme dans le batch qui tourne tous les soirs)

utilisation du Steam PICS pour récupérer les dernières updates de jeu :
- s'il y a un changement sur un jeu ou démo, qui a des succès, on fait la différence entre ce que l'on a en BDD et ce que l'on a récupéré
- si des succès sont enlevés : message avec les succès enlevés
- idem pour ceux ajoutés
il se peut que, sur les jeux pas encore présents en BDD, un message s'affiche avec tous les succès. A voir plus tard
- utilisation d'un channel 'feed' pour afficher ces messages

et + tout ce qui est config de l'url du webhook, via /salon