### PR TITLE
Update perm pin message

### DIFF
--- a/slash_commands/subcommands/group/create.js
+++ b/slash_commands/subcommands/group/create.js
@@ -222,7 +222,7 @@ const create = async (interaction, options) => {
             {
                 id: captain.id,
                 allow: [
-                    PermissionFlagsBits.ManageMessages,
+                    PermissionFlagsBits.PinMessages,
                     PermissionFlagsBits.SendMessages,
                     PermissionFlagsBits.ViewChannel,
                 ],

--- a/slash_commands/subcommands/group/transfert.js
+++ b/slash_commands/subcommands/group/transfert.js
@@ -71,6 +71,18 @@ const transfert = async (interaction, options) => {
         .fetch(oldCaptainDb.userId)
         .catch(() => null);
 
+    if (newCaptain === oldCaptain) {
+        return interaction.editReply({
+            embeds: [
+                createError(
+                    isAdmin
+                        ? `${newCaptain} a déjà pris la tête de l’escouade 🎮`
+                        : `Tu es déjà capitaine du groupe 😄`,
+                ),
+            ],
+        });
+    }
+
     // update du groupe : captain
     await client.update(grp, {
         captain: newCaptainDb,

--- a/slash_commands/subcommands/group/transfert.js
+++ b/slash_commands/subcommands/group/transfert.js
@@ -12,11 +12,13 @@ const transfert = async (interaction, options) => {
 
     const isAdmin = author.permissions.has(PermissionFlagsBits.Administrator);
 
+    await interaction.deferReply();
+
     // Test si le capitaine est inscrit
     const authorDb = await client.getUser(author);
     if (!authorDb) {
         // Si pas dans la BDD
-        return interaction.reply({
+        return interaction.editReply({
             embeds: [
                 createError(
                     `${author.user.tag} n'a pas encore de compte ! Pour s'enregistrer : \`/register\``,
@@ -26,7 +28,7 @@ const transfert = async (interaction, options) => {
     }
     const newCaptainDb = await client.getUser(newCaptain);
     if (!newCaptainDb) {
-        return interaction.reply({
+        return interaction.editReply({
             embeds: [
                 createError(
                     `${newCaptain} n'a pas de compte ! Merci de t'enregistrer avec la commande : \`/register\``,
@@ -38,14 +40,14 @@ const transfert = async (interaction, options) => {
     // Récupération du groupe
     const grp = await client.findGroupByName(grpName);
     if (!grp) {
-        return interaction.reply({
+        return interaction.editReply({
             embeds: [createError(`Le groupe **${grpName}** n'existe pas !`)],
         });
     }
 
     // Si l'auteur n'est pas admin et n'est pas capitaine
     if (!isAdmin && !grp.captain._id.equals(authorDb._id)) {
-        return interaction.reply({
+        return interaction.editReply({
             embeds: [
                 createError(`Tu n'es pas capitaine du groupe **${grpName}** !`),
             ],
@@ -55,7 +57,7 @@ const transfert = async (interaction, options) => {
     // si le nouveau capitaine fait parti du groupe
     const memberGrp = grp.members.find((u) => u._id.equals(newCaptainDb._id));
     if (!memberGrp) {
-        return interaction.reply({
+        return interaction.editReply({
             embeds: [
                 createError(
                     `${newCaptain} ne fait pas parti du groupe **${grpName}** !`,
@@ -102,7 +104,7 @@ const transfert = async (interaction, options) => {
     const newMsgEmbed = new EmbedBuilder().setDescription(
         `${CHECK_MARK} ${newCaptain} est le nouveau capitaine du groupe **${grpName}** !`,
     );
-    await interaction.reply({ embeds: [newMsgEmbed] });
+    await interaction.editReply({ embeds: [newMsgEmbed] });
 };
 
 exports.transfert = transfert;


### PR DESCRIPTION
### Feat
- Ajout d'une protection empêchant de se transféré le rôle de capitaine à soi-même

### Fix
- Update de la permission pour épinglé les messages qui va devenir obsolète en janvier 2026 : `ManageMessages` --> `PinMessages`
- Crash si dépassement des 3sec de délais pour la commande `group transfert`
