### PR TITLE
Tower s1 update

### DIFF
--- a/data/event/tower/constants.json
+++ b/data/event/tower/constants.json
@@ -385,6 +385,22 @@
                 "«Le tag ou le genre manquent encore…» Le Boss sourit et récupère un PV, visiblement ravi.",
                 "Vous avez trébuché sur les règles ! Le Boss s’approche et un PV lui revient comme une offrande.",
                 "Vous avez oublié le tag ou le genre du mois… Le Boss récupère un PV avec un petit rire cruel."
+            ],
+            "ADMIN_HEAL": [
+                "Un stalker a pensé aider l’équipe. Mauvais calcul : +1 PV pour le Boss.",
+                "Un stalker a passé des heures à traquer des collectibles inutiles. Résultat concret : +1 PV pour le Boss.",
+                "Un stalker a sacrifié son temps libre pour la science… et pour soigner le Boss (+1 PV).",
+                "Un stalker a transformé un 100% en acte médical non consenti. Le Boss se régénère (+1 PV).",
+                "Plume décide de PL les stalkers, le boss reprend un pv",
+                "Un stalker a fini un jeu pendant que plume marchait sur son clavier. Le Boss profite pour récupérer +1 PV.",
+                "Un stalker ne vous aime pas et donne un PV au boss. Tu vas faire quoi hein???",
+                "Un stalker a fini un jeu. Le Boss se régale (+1 PV).",
+                "Plume vient en aide à Nanaki : le Boss récupère +1 PV.",
+                "Tigrou a trouvé un bundle à 1 centime. Jour de fête, le Boss récupère +1 PV.",
+                "Sqweeb a fini un jeu à plus de 5 €. Miracle : le Boss récupère +1 PV.",
+                "Cyborg a fini un jeu sans rager. Impossible… le Boss trinque avec lui et récupère +1 PV.",
+                "Un stalker avait trop de temps libre : il vient de finir un jeu. +1 PV pour le Boss.",
+                "Un stalker a touché de l’herbe… puis a fini un jeu. +1 PV pour le Boss."
             ]
         }
     },

--- a/data/event/tower/constants.json
+++ b/data/event/tower/constants.json
@@ -230,6 +230,7 @@
             "DAMAGE": 1,
             "NB_YEARS_SMALL_BONUS": 5,
             "NB_YEARS_BONUS": 10,
+            "HEAL_CHANCE": 0.15,
             "HIDDEN_GAME_APPID": {
                 "489830": "Cyborg",
                 "260230": "Cyborg",
@@ -358,6 +359,32 @@
                     "killed": "En complétant **${gameName}**, ${author} porte le coup fatal à `Sqweeb` !",
                     "dead": "En complétant **${gameName}**, ${author} arrive au **palier n°4** !\nMais `Sqweeb` ayant été vaincu, il n'y a plus rien à voir ici."
                 }
+            ],
+            "HEAL": [
+                "Un oubli dans le jeu ! Le Boss lève un sourcil, récupère un PV et vous observe comme si vous étiez des insectes.",
+                "Le genre et le tag du mois ont été oubliés… Le Boss se frotte les mains et regagne 1 PV.",
+                "Vous croyez avoir tout validé ? Le Boss surgit de l’ombre et un PV lui revient aussitôt.",
+                "Le tag ou le genre du mois ont été zappés… Le Boss soupire et récupère un PV en soupirant de façon dramatique.",
+                "Dans un éclair de colère, le Boss récupère un PV alors qu’un joueur trébuche sur les règles.",
+                "Un oubli de tag ou de genre ? Parfait ! Le Boss incline la tête et regagne 1 PV, satisfait.",
+                "Les règles ont été bafouées. Le Boss frappe sa table, et un PV revient à lui comme par magie.",
+                "Le Boss apparaît derrière vous, les bras croisés… et récupère un PV volé par votre négligence.",
+                "Une validation incomplète ! Le Boss se penche, ramasse un PV et le tient comme un trophée.",
+                "Le tag ou le genre manquent… Le Boss sourit, et un PV lui revient sans effort.",
+                "Le Boss observe vos erreurs et récupère un PV avec un petit rire  inquiétant.",
+                "Vous avez oublié le genre ou le tag du mois… Le Boss s’incline légèrement et regagne un PV.",
+                "Le Boss frappe du pied : le sol tremble et un PV s’ajoute à sa réserve.",
+                "Une bévue ! Le Boss tourne autour de vous, récupérant un PV comme un prédateur subtil.",
+                "Le tag ou le genre ont disparu… Le Boss hausse un sourcil et reprend un PV.",
+                "Un PV revient au Boss tandis que vous regardez, impuissants, l’erreur flagrante que vous avez commise.",
+                "Le Boss s’assoit tranquillement et un PV revient à lui, conséquence de votre négligence.",
+                "Le Boss soupire et récupère un PV, visiblement amusé par votre maladresse.",
+                "Tag ou genre manquant ? Le Boss étire ses doigts et récupère un PV en riant doucement.",
+                "Le Boss se tient droit, les mains derrière le dos, et récupère un PV avec calme.",
+                "Vous avez zappé le genre ou le tag ? Le Boss s’avance et un PV lui revient instantanément.",
+                "«Le tag ou le genre manquent encore…» Le Boss sourit et récupère un PV, visiblement ravi.",
+                "Vous avez trébuché sur les règles ! Le Boss s’approche et un PV lui revient comme une offrande.",
+                "Vous avez oublié le tag ou le genre du mois… Le Boss récupère un PV avec un petit rire cruel."
             ]
         }
     },

--- a/slash_commands/admin.js
+++ b/slash_commands/admin.js
@@ -1,7 +1,13 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require("discord.js");
 const { createError } = require("../util/envoiMsg");
 const { cancel, refund, deleteItem } = require("./subcommands/admin/shop");
-const { start, stop, down, allGame } = require("./subcommands/admin/tower");
+const {
+    start,
+    stop,
+    down,
+    allGame,
+    heal,
+} = require("./subcommands/admin/tower");
 const {
     add: addObservation,
     remove: removeObservation,
@@ -39,6 +45,24 @@ module.exports = {
                                 .setName("user")
                                 .setDescription("L'utilisateur")
                                 .setRequired(true),
+                        ),
+                )
+                .addSubcommand((sub) =>
+                    sub
+                        .setName("heal")
+                        .setDescription(
+                            "Valider un jeu (100%) et soigner le boss courant",
+                        )
+                        .addIntegerOption((option) =>
+                            option
+                                .setName("appid")
+                                .setDescription("Appid du jeu Steam"),
+                        )
+                        .addIntegerOption((option) =>
+                            option
+                                .setName("jeu")
+                                .setDescription("Nom du jeu")
+                                .setAutocomplete(true),
                         ),
                 )
                 .addSubcommand((sub) =>
@@ -347,6 +371,8 @@ module.exports = {
                 await allGame(interaction, interaction.options);
             } else if (subcommand === "down") {
                 await down(interaction, interaction.options);
+            } else if (subcommand === "heal") {
+                await heal(interaction, interaction.options);
             }
         } else if (subcommandGroup === "shop") {
             if (subcommand === "cancel") {

--- a/slash_commands/admin.js
+++ b/slash_commands/admin.js
@@ -292,7 +292,7 @@ module.exports = {
 
         let filtered = [];
 
-        if (focusedValue.name === "jeu") {
+        if (focusedValue.name === "jeu" && focusedValue.value) {
             if (focusedValue.value) {
                 filtered = await client.findGameItemShopBy({
                     game: focusedValue.value,

--- a/slash_commands/admin.js
+++ b/slash_commands/admin.js
@@ -292,7 +292,7 @@ module.exports = {
 
         let filtered = [];
 
-        if (focusedValue.name === "jeu" && focusedValue.value) {
+        if (focusedValue.name === "jeu") {
             if (focusedValue.value) {
                 filtered = await client.findGameItemShopBy({
                     game: focusedValue.value,

--- a/slash_commands/group.js
+++ b/slash_commands/group.js
@@ -170,7 +170,7 @@ module.exports = {
         let exact = [];
 
         // cmd group create, autocomplete sur nom jeu multi/coop avec succès
-        if (focusedValue.name === "jeu" && focusedValue.value != "") {
+        if (focusedValue.name === "jeu" && focusedValue.value) {
             // recherche nom exacte
             exact = await client.findGames({
                 name: focusedValue.value,

--- a/slash_commands/shop.js
+++ b/slash_commands/shop.js
@@ -86,7 +86,7 @@ module.exports = {
                 let exact = [];
 
                 // cmd shop sell, autocomplete sur nom jeu
-                if (focusedValue.name === "jeu" && focusedValue.value != "") {
+                if (focusedValue.name === "jeu" && focusedValue.value) {
                     // recherche nom exacte
                     exact = await interaction.client.findGames({
                         name: focusedValue.value,
@@ -153,7 +153,7 @@ module.exports = {
 
                 let filtered = [];
 
-                if (focusedValue.name === "jeu") {
+                if (focusedValue.name === "jeu" && focusedValue.value) {
                     if (focusedValue.value) {
                         filtered = await interaction.client.findGameItemShopBy({
                             game: focusedValue.value,

--- a/slash_commands/shop.js
+++ b/slash_commands/shop.js
@@ -153,7 +153,7 @@ module.exports = {
 
                 let filtered = [];
 
-                if (focusedValue.name === "jeu" && focusedValue.value) {
+                if (focusedValue.name === "jeu") {
                     if (focusedValue.value) {
                         filtered = await interaction.client.findGameItemShopBy({
                             game: focusedValue.value,

--- a/slash_commands/subcommands/admin/tower/heal.js
+++ b/slash_commands/subcommands/admin/tower/heal.js
@@ -24,8 +24,6 @@ async function heal(interaction, options) {
     await interaction.deferReply({ ephemeral: true });
     const adminDb = await client.getUser(author);
 
-    // TODO : vérifier que l'utilisateur est admin ou modérateur
-
     // Récupération du channel de l'event
     const eventChannelId = await interaction.client.getGuildChannel(
         interaction.guild.id,

--- a/slash_commands/subcommands/admin/tower/heal.js
+++ b/slash_commands/subcommands/admin/tower/heal.js
@@ -1,0 +1,194 @@
+const { GuildConfig, TowerBoss } = require("../../../../models");
+const { SALON } = require("../../../../util/constants");
+const {
+    createError,
+    createLogs,
+    createEmbed,
+} = require("../../../../util/envoiMsg");
+const {
+    healBoss,
+    displayHealth,
+} = require("../../../../util/events/tower/towerUtils");
+const { MESSAGE } = require("../../../../data/event/tower/constants.json");
+
+async function heal(interaction, options) {
+    const guildId = interaction.guildId;
+    const guild = await GuildConfig.findOne({ guildId: guildId });
+    let appid = options.getInteger("appid");
+    appid = !appid ? options.get("jeu")?.value : appid;
+    logger.info(`.. lancement heal event tower (${appid})`);
+
+    const author = interaction.member;
+    const client = interaction.client;
+
+    await interaction.deferReply({ ephemeral: true });
+    const adminDb = await client.getUser(author);
+
+    // TODO : vérifier que l'utilisateur est admin ou modérateur
+
+    // Récupération du channel de l'event
+    const eventChannelId = await interaction.client.getGuildChannel(
+        interaction.guild.id,
+        SALON.EVENT_TOWER,
+    );
+
+    // Gestion d'erreur si aucun salon n'est défini
+    if (!eventChannelId) {
+        return interaction.editReply({
+            content: `Aucun salon de l'évènement tower n'a été trouvé.`,
+        });
+    }
+    // si la saison n'a pas encore commencé
+    if (!guild.event.tower.started) {
+        logger.info(".. évènement tower pas encore commencé");
+        return await interaction.editReply({
+            embeds: [createError("L'évènement n'a pas encore commencé..")],
+        });
+    }
+
+    // si pas encore inscrit
+    if (typeof adminDb.event.tower.startDate === "undefined") {
+        return await interaction.editReply({
+            embeds: [
+                createError(
+                    "Tu dois d'abord t'inscrire à l'évènement (via `/tower inscription`) !",
+                ),
+            ],
+        });
+    }
+
+    // appid doit être tjs présent
+    if (!appid) {
+        return await interaction.editReply({
+            embeds: [
+                createError(
+                    "Tu dois spécifier au moins un appID ou chercher le jeu que tu as complété",
+                ),
+            ],
+        });
+    }
+
+    const season = guild.event.tower.currentSeason;
+
+    // recup boss courant
+    const currentBoss = await TowerBoss.findOne({
+        season: season,
+        hp: { $gt: 0 },
+    });
+    if (!currentBoss) {
+        return interaction.editReply({
+            content: "Aucun boss n'est actif actuellement. Heal impossible.",
+        });
+    }
+
+    // récupération des infos des succès sur le jeu sélectionné via Steam
+    const steamId = adminDb.steamId;
+
+    const {
+        error,
+        noAchievements,
+        gameName,
+        hasAllAchievements,
+        firstUnlock,
+        finishedAfterStart,
+    } = await client.hasAllAchievementsAfterDate(
+        steamId,
+        appid,
+        guild.event.tower.startDate,
+    );
+
+    if (error) {
+        logger.warn(
+            `.. erreur lors de la recherche de succès pour l'appid ${appid} :\n${error}`,
+        );
+        // Recup nom du jeu, si présent dans la bdd
+        return await interaction.editReply({
+            content: `${gameName} (${appid}) n'est pas dans ta bibliothèque ou n'a pas de succès..`,
+        });
+    }
+
+    if (noAchievements) {
+        logger.warn(`.. ${error}`);
+        // Recup nom du jeu, si présent dans la bdd
+        return await interaction.editReply({
+            content: `${gameName} (${appid}) n'a même pas de succès..`,
+        });
+    }
+
+    // Vérifier si l'utilisateur a déjà 100% le jeu
+    if (adminDb.event.tower.completedGames.includes(appid)) {
+        logger.warn({
+            prefix: "ADMIN TOWER",
+            message: `${author.user.tag} 100% ${gameName} (${appid}): déjà fait ..`,
+        });
+        return await interaction.editReply({
+            content: `Tu as déjà utilisé ${gameName}.. ce n'est pas très efficace.`,
+        });
+    }
+
+    if (!hasAllAchievements) {
+        return await interaction.editReply({
+            content: `Tu n'as pas encore complété ${gameName}..`,
+        });
+    }
+
+    if (!finishedAfterStart) {
+        logger.warn({
+            prefix: "ADMIN TOWER",
+            message: `${author.user.tag} 100% ${gameName} (${appid}): avant le début de l'event ..`,
+        });
+        return await interaction.editReply({
+            content: `Tu as terminé ${gameName} **avant** le début de l'évènement.. Celui-ci ne peut être pris en compte.`,
+        });
+    }
+
+    // on peut heal !!
+    if (hasAllAchievements) {
+        adminDb.event.tower.completedGames.push(appid); // Ajouter l'appId aux jeux déjà 100%
+        await adminDb.save();
+
+        // heal le boss
+        await healBoss(currentBoss);
+        const descHeal = randomHealDesc();
+
+        // logs
+        await createLogs(
+            client,
+            guildId,
+            `🗼 ADMIN TOWER [${season}] : Nouveau jeu validé`,
+            `${author} vient de valider **${gameName}** (${appid}) ! Le boss se heal !`,
+            "",
+            "#DC8514",
+        );
+
+        const embed = createEmbed({
+            title: "🛡️ Intervention d'un stalker",
+            url: `https://store.steampowered.com/app/${appid}/`,
+            desc: descHeal,
+            color: "#00b7ff",
+            footer: {
+                text: `Le boss récupère des forces...`,
+            },
+        });
+        embed.addFields({
+            name: `${currentBoss.hp}/${currentBoss.maxHp}`,
+            value: `${displayHealth(currentBoss)}`,
+        });
+
+        await client.channels.cache
+            .get(eventChannelId)
+            .send({ embeds: [embed] });
+        return interaction.editReply("Ton jeu a bien soigné le boss !");
+    }
+
+    return await interaction.editReply({
+        content: "Il faut d'abord terminer le jeu !",
+    });
+}
+
+function randomHealDesc() {
+    const heals = MESSAGE["1"].ADMIN_HEAL;
+    return heals[Math.floor(Math.random() * heals.length)];
+}
+
+exports.heal = heal;

--- a/slash_commands/subcommands/admin/tower/index.js
+++ b/slash_commands/subcommands/admin/tower/index.js
@@ -2,10 +2,12 @@ const { start } = require("./start");
 const { stop } = require("./stop");
 const { down } = require("./down");
 const { allGame } = require("./all-game");
+const { heal } = require("./heal");
 
 module.exports = {
     start,
     stop,
     down,
     allGame,
+    heal,
 };

--- a/slash_commands/subcommands/admin/tower/start.js
+++ b/slash_commands/subcommands/admin/tower/start.js
@@ -1,6 +1,5 @@
 const { GuildConfig } = require("../../../../models");
 const { createLogs } = require("../../../../util/envoiMsg");
-const { daysDiff } = require("../../../../util/util");
 
 async function start(interaction) {
     const guild = await GuildConfig.findOne({

--- a/slash_commands/subcommands/tower/valider-jeu.js
+++ b/slash_commands/subcommands/tower/valider-jeu.js
@@ -57,7 +57,7 @@ const validerJeu = async (interaction, options) => {
         });
     }
 
-    // si la saison n'a pas encore commencé (à faire manuellement via commage '<préfix>tower start')
+    // si la saison n'a pas encore commencé (à faire manuellement via commande '<préfix>tower start')
     if (!guild.event.tower.started) {
         logger.info(".. évènement tower pas encore commencé");
         return await interaction.editReply({
@@ -65,7 +65,7 @@ const validerJeu = async (interaction, options) => {
         });
     }
 
-    // si pas inscrit
+    // si pas encore inscrit
     if (typeof userDb.event.tower.startDate === "undefined") {
         return await interaction.editReply({
             embeds: [

--- a/slash_commands/tower.js
+++ b/slash_commands/tower.js
@@ -56,7 +56,7 @@ module.exports = {
         let exact = [];
 
         // cmd boss valider, autocomplete sur nom jeu
-        if (focusedValue.name === "jeu") {
+        if (focusedValue.name === "jeu" && focusedValue.value) {
             // recherche nom exacte
             exact = await client.findGames({
                 name: focusedValue.value,

--- a/util/batch/batch.js
+++ b/util/batch/batch.js
@@ -478,7 +478,9 @@ module.exports = {
                                 );
                                 continue;
                             }
-                            if (guildConfig?.event?.tower?.currentSeason === 0) {
+                            if (
+                                guildConfig?.event?.tower?.currentSeason === 0
+                            ) {
                                 continue;
                             }
 

--- a/util/events/tower/season.js
+++ b/util/events/tower/season.js
@@ -9,6 +9,7 @@ const {
     getRandomPrivateJokes,
     displayHealth,
     endSeason,
+    healBoss,
 } = require("./towerUtils");
 const { TowerBoss } = require("../../../models");
 const { AttachmentBuilder, EmbedBuilder } = require("discord.js");
@@ -519,7 +520,7 @@ async function seasonOne(
     for (let i = 0; i <= step; i++) {
         isPalierAtteint |=
             (userDb.event.tower.currentEtage + i) %
-            SEASONS["1"].ETAGE_PAR_PALIER ===
+                SEASONS["1"].ETAGE_PAR_PALIER ===
             0;
         if (isPalierAtteint) {
             step = i;
@@ -555,7 +556,7 @@ async function seasonOne(
     // dans le cas où on arrive à un palier, on incrémente d'abord l'étage courant
     if (
         (userDb.event.tower.currentEtage + step) %
-        SEASONS["1"].ETAGE_PAR_PALIER ===
+            SEASONS["1"].ETAGE_PAR_PALIER ===
         0
     ) {
         // si step 0 (on est pile au palier), on monte d'un étage
@@ -734,13 +735,18 @@ async function seasonOne(
 
     if (healTriggered) {
         // On soigne le boss au lieu d'infliger des dégâts
-        const healAmount = 1; // on soigne que de 1 quand même
-        currentBoss.hp = Math.min(currentBoss.maxHp, currentBoss.hp + healAmount); // pas + haut que le bord
-        await currentBoss.save();
+        await healBoss(currentBoss);
 
         // Log et message pour le salon event
         const descHeal = randomHealDesc();
-        await createLogs(client, guildId, `🗼 - Malus : soin du boss`, descHeal, "", "#5DADE2");
+        await createLogs(
+            client,
+            guildId,
+            `🗼 - Malus : soin du boss`,
+            descHeal,
+            "",
+            "#5DADE2",
+        );
 
         const embedHeal = initEmbed(
             `🏥 Pas de chance...`,
@@ -755,9 +761,13 @@ async function seasonOne(
             value: `${displayHealth(currentBoss)}`,
         });
 
-        await client.channels.cache.get(eventChannelId).send({ embeds: [embedHeal] });
+        await client.channels.cache
+            .get(eventChannelId)
+            .send({ embeds: [embedHeal] });
 
-        return interaction.editReply("Ton jeu a involontairement soigné le boss !");
+        return interaction.editReply(
+            "Ton jeu a involontairement soigné le boss !",
+        );
     }
 
     // si pas de soin, on applique les dégâts comme avant

--- a/util/events/tower/towerUtils.js
+++ b/util/events/tower/towerUtils.js
@@ -65,6 +65,18 @@ async function isAllBossDead(season) {
 }
 
 /**
+ * Soigne le boss.
+ *
+ * @param {Object} boss - Towerboss.
+ * @returns {Promise<void>}
+ */
+async function healBoss(boss) {
+    const healAmount = 1; // on soigne que de 1 quand même
+    boss.hp = Math.min(boss.maxHp, boss.hp + healAmount); // pas + haut que le bord
+    await boss.save();
+}
+
+/**
  * Termine la saison pour un utilisateur donné, sauvegarde les données de la saison dans l'historique et réinitialise les données pour la nouvelle saison
  * @param {Object} user - Utilisateur dont on termine la saison
  * @param {number} endDate - Timestamp de fin de la saison
@@ -182,7 +194,7 @@ async function endSeasonZero() {
 async function endSeasonOne() {
     const currentBoss = await TowerBoss.findOne({
         season: 1,
-        hp: { $ne: 0 },
+        hp: { $gt: 0 },
     });
     if (!currentBoss) return MESSAGE["1"].START_BAD_ENDING;
 
@@ -193,5 +205,6 @@ module.exports = {
     displayHealth,
     getRandomPrivateJokes,
     isAllBossDead,
+    healBoss,
     endSeason,
 };


### PR DESCRIPTION
EVENT TOWER 
Ajout de possibilités de soigner le boss : 
- lors d'une validation d'un jeu qui ne contient aucun tag/genres du mois, a une chance de 15% de proc
- lors de la validation d'un jeu mais côté admin, via la commande `/admin tower heal <appid>`