### PR TITLE
HP boss ++ et % heal ++

### DIFF
--- a/data/event/tower/constants.json
+++ b/data/event/tower/constants.json
@@ -230,7 +230,7 @@
             "DAMAGE": 1,
             "NB_YEARS_SMALL_BONUS": 5,
             "NB_YEARS_BONUS": 10,
-            "HEAL_CHANCE": 0.05,
+            "HEAL_CHANCE": 0.1,
             "HIDDEN_GAME_APPID": {
                 "489830": "Cyborg",
                 "260230": "Cyborg",
@@ -282,7 +282,7 @@
             },
             {
                 "name": "Sqweeb",
-                "hp": 250,
+                "hp": 320,
                 "image": {
                     "alive": "sqweeb.png",
                     "dead": "sqweeb_dead.jpg"

--- a/util/events/tower/season.js
+++ b/util/events/tower/season.js
@@ -442,8 +442,10 @@ async function seasonOne(
     // par défaut, on monte d'un étage
     let step = 1;
     // si jeu caché / tag du mois / backlog, on monte d'un étage supplémentaire
-    const nbYearsSmallBonus = process.env.NB_YEARS_SMALL_BONUS || SEASONS["1"].NB_YEARS_SMALL_BONUS;
-    const nbYearsBonus = process.env.NB_YEARS_BONUS || SEASONS["1"].NB_YEARS_BONUS;
+    const nbYearsSmallBonus =
+        process.env.NB_YEARS_SMALL_BONUS || SEASONS["1"].NB_YEARS_SMALL_BONUS;
+    const nbYearsBonus =
+        process.env.NB_YEARS_BONUS || SEASONS["1"].NB_YEARS_BONUS;
     if (
         isHiddenApp ||
         isMonthlyGenre ||
@@ -729,7 +731,8 @@ async function seasonOne(
     }
 
     // si aucun tag ni genre du mois n'a été trouvé, il y a une petite chance que le jeu soigne le boss au lieu de le blesser.
-    const HEAL_CHANCE = parseFloat(process.env.HEAL_CHANCE) || SEASONS["1"].HEAL_CHANCE;
+    const HEAL_CHANCE =
+        parseFloat(process.env.HEAL_CHANCE) || SEASONS["1"].HEAL_CHANCE;
     const willAttemptHeal = !isHiddenApp && !isMonthlyGenre && !isMonthlyTag; // aucun tag/genre trouvé ni un jeu caché
     const healTriggered = willAttemptHeal && Math.random() < HEAL_CHANCE;
 


### PR DESCRIPTION
Message de Sqweeb :
On est en Avril, Nanaki se fait défoncer, je pense que
on va passer à 10% la possibilité de regen le boss si il n'y a pas de tag, et mes pvs ben le double de nanaki ^^' 320, si c'est possible ^^

c'est une petite PR qui ne devrait pas nécessité de review mais bon, j'attends quand meme